### PR TITLE
Change keyword in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "Node-RED",
+    "node-red",
     "process",
     "env"
   ],


### PR DESCRIPTION
Other nodes in the flow library use "node-red" as the keyword in package.json. Not "Node-RED".
If you want to register it on flow, please try to change the keyword.
(Sorry in advance if there're another reason not to able to register it on the flow library)